### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "BSD-2-Clause"
 keywords = ["CVE", "NIST", "vulnerability"]
 categories = ["command-line-utilities", "caching"]
 readme = "README.md"
-homepage = "https://github.com/travispaul/nvd_cve"
+repository = "https://github.com/travispaul/nvd_cve"
 description = "Search for CVEs against a local cached copy of NIST National Vulnerability Database (NVD)."
 
 [dependencies]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.